### PR TITLE
Fftwheader

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ export condaname="fermitools"
 # To checkout arbitrary other refs (Tag, Branch, Commit) add them as a space
 #   delimited list after 'conda' in the order of priority.
 #   e.g. ScienceTools highest_priority_commit middle_priority_ref branch1 branch2 ... lowest_priority
-repoman --remote-base https://github.com/fermi-lat checkout --force --develop ScienceTools conda fftwheader
+repoman --remote-base https://github.com/fermi-lat checkout --force --develop ScienceTools fftwheader conda
 # repoman --remote-base https://github.com/fermi-lat checkout --force --develop ScienceTools conda STGEN-182
 
 

--- a/build.sh
+++ b/build.sh
@@ -10,16 +10,6 @@ repoman --remote-base https://github.com/fermi-lat checkout --force --develop Sc
 # repoman --remote-base https://github.com/fermi-lat checkout --force --develop ScienceTools conda STGEN-182
 
 
-# condaforge fftw is in a different spot
-mkdir -p ${PREFIX}/include/fftw
-if [ ! -e ${PREFIX}/include/fftw/fftw3.h ] ; then
-
-    ln -s ${PREFIX}/include/fftw3.* ${PREFIX}/include/fftw
-
-fi
-
-#CXXFLAGS=${CXXFLAGS//c++17/c++11}
-
 # Add optimization
 export CFLAGS="-O2 ${CFLAGS}"
 export CXXFLAGS="-O2 ${CXXFLAGS}"

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ export condaname="fermitools"
 # To checkout arbitrary other refs (Tag, Branch, Commit) add them as a space
 #   delimited list after 'conda' in the order of priority.
 #   e.g. ScienceTools highest_priority_commit middle_priority_ref branch1 branch2 ... lowest_priority
-repoman --remote-base https://github.com/fermi-lat checkout --force --develop ScienceTools conda
+repoman --remote-base https://github.com/fermi-lat checkout --force --develop ScienceTools conda fftwheader
 # repoman --remote-base https://github.com/fermi-lat checkout --force --develop ScienceTools conda STGEN-182
 
 


### PR DESCRIPTION
This feature removes the need to create a separate symbolic link for the fftw headers in conda versions of the build.

Adds new pre-processor definition "CONDA_FFTW" for conda versions of fftw.
Uses #ifdef macro to conditionally include "fftw3.h" when that definition is set, rather than the existing "fftw/fftw3.h" when it is not.

updated headers in Likelihood, periodSearch, pgwave.
also updated Fermitools-conda, and SConsShared.

total list of repositories with "fftwheader" branch that need to be merged:
- [ ] Fermitools-conda
- [ ] SConsShared
- [ ] Likelihood
- [ ] periodSearch
- [ ] pgwave