### PR TITLE
St issue18

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,3 +1,6 @@
 CONDA_BUILD_SYSROOT:
   # - /opt/MacOSX10.13.sdk #[osx]
   - /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk  #[osx]
+
+numpy:
+  - 1.20

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,6 +18,7 @@ cmake -S . \
   -DCMAKE_PREFIX_PATH="${PREFIX}" \
   -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
   -DPython3_EXECUTABLE="${BUILD_PREFIX}/bin/python3" \
+  -DPython3_NumPy_INCLUDE_DIR="${SP_DIR}/numpy/core/include" \
   -DCMAKE_TOOLCHAIN_FILE="${TOOLCHAIN_FILE}" \
   ${CMAKE_ARGS}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,6 +7,7 @@ package:
 
 source:
   git_url: https://github.com/fermi-lat/Sciencetools.git
+  git_rev: Issue18
 
 build:
   number: {{ environ.get('BUILD_NUMBER', 0)}}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,6 @@ package:
 
 source:
   git_url: https://github.com/fermi-lat/Sciencetools.git
-  git_rev: Issue18
 
 build:
   number: {{ environ.get('BUILD_NUMBER', 0)}}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ build:
     - {{ pin_compatible('fftw', max_pin='x.x') }}
     - {{ pin_compatible('gsl', max_pin='x.x') }}
     - {{ pin_compatible('healpix_cxx', max_pin='x.x') }}
+    - {{ pin_compatible('numpy', max_pin='x.x') }}
     - {{ pin_compatible('python', max_pin='x.x') }}
     - {{ pin_compatible('readline', max_pin='x.x') }}
     - {{ pin_compatible('wcslib', max_pin='x.x') }}
@@ -72,7 +73,7 @@ requirements:
     - fftw
     - gsl
     - healpix_cxx 3.31
-    - numpy
+    - numpy >=1.20
     - python 3.9.*
     - readline
     - wcslib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "fermitools" %}
-{% set version = "2.2.0" %}
+{% set version = "2.2.11" %}
 
 package:
   name: {{ name|lower }}
@@ -20,7 +20,7 @@ build:
     - {{ pin_compatible('fftw', max_pin='x.x') }}
     - {{ pin_compatible('gsl', max_pin='x.x') }}
     - {{ pin_compatible('healpix_cxx', max_pin='x.x') }}
-    - {{ pin_compatible('numpy', max_pin='x.x') }}
+    - {{ pin_compatible('numpy', lower_bound='1.18', upper_bound='2.0') }}
     - {{ pin_compatible('python', max_pin='x.x') }}
     - {{ pin_compatible('readline', max_pin='x.x') }}
     - {{ pin_compatible('wcslib', max_pin='x.x') }}
@@ -73,7 +73,7 @@ requirements:
     - fftw
     - gsl
     - healpix_cxx 3.31
-    - numpy >=1.20
+    - numpy
     - python 3.9.*
     - readline
     - wcslib
@@ -105,6 +105,7 @@ test:
     - py_facilities
     - pyLikelihood
     - UnbinnedAnalysis
+    - skymaps
 
   requires:
     - fermitools-test-scripts-data

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,6 +71,7 @@ requirements:
     - fftw
     - gsl
     - healpix_cxx 3.31
+    - numpy
     - python 3.9.*
     - readline
     - wcslib


### PR DESCRIPTION
Fix for Sciencetools Issue 18. Adds skymaps python module and new external dependency on numpy.

Note, Must commit removal of meta.py source: git_rev line before merge.